### PR TITLE
Fixed alerts CSS-mapping for Tapestry 5.3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,7 @@ Any other CSS classes can be additionally specified here, i.e., bootstrap "well"
 Add fwtype parameter to the Alerts. If the value is null the Alerts looks as before.
 Value fwtype="alert" changes look and feel according to [bootstrap alerts](http://twitter.github.com/bootstrap/components.html#alerts).
 
-Until [TAP5-1996](https://issues.apache.org/jira/browse/TAP5-1996) fixed Tap5 alerts will use this mapping:
-Tap5 'info' -> 'alert-success'
-Tap5 'warn' -> 'alert'
-Tap5 'error' -> 'alert-error'
+Alerts will work better with Tapestry 5.3.6 and above (see [TAP5-1996](https://issues.apache.org/jira/browse/TAP5-1996)).
 
 
 ## Customizing Bootstrap:

--- a/src/main/resources/com/trsvax/bootstrap/t5-bootstrap-alerts.js
+++ b/src/main/resources/com/trsvax/bootstrap/t5-bootstrap-alerts.js
@@ -10,7 +10,7 @@
             
             $alert.removeClass();
             
-            $alert.addClass("alert " + addClass);
+            $alert.addClass("alert" + (addClass == "" ? "" : " ") + addClass);
             
             var $dismiss = $alert.children(".t-dismiss").first();
             
@@ -29,9 +29,12 @@
                     makeBootstrapAlert($(this), "alert-error");
                 });
                 $alerts.filter("DIV.t-warn").each(function(){
-                    makeBootstrapAlert($(this), "alert");
+                    makeBootstrapAlert($(this), "");
                 });
                 $alerts.filter("DIV.t-info").each(function(){
+                    makeBootstrapAlert($(this), "alert-info");
+                });
+                $alerts.filter("DIV.t-success").each(function(){
                     makeBootstrapAlert($(this), "alert-success");
                 });
                 


### PR DESCRIPTION
Hi,

the patch for Tapestry 5.3.6 alerts (support for SUCCESS alert type).

It will work for versions < 5.3.6 also but there won't be alert-success.
